### PR TITLE
Avoid negative hash number.

### DIFF
--- a/libexec/mode_quiz.rb
+++ b/libexec/mode_quiz.rb
@@ -400,7 +400,7 @@ class QuizFlavour
     puts "\e[0m"
     puts
     puts "Mnemonic songs are:  \e[2m"
-    $quiz_interval2song[@dsemi].each do |song|
+    $quiz_interval2song[@dsemi.abs].each do |song|
       puts "   " + song
     end
     puts "\e[0m"


### PR DESCRIPTION
I don't know if this is the best way to fix it, but when the interval is decreasing in pitch, the program crashes because a negative number is trying to be used as a list or hash index.